### PR TITLE
fix: catch ccxt load market exception

### DIFF
--- a/realtime/src/services/exchanges/ccxt/index.ts
+++ b/realtime/src/services/exchanges/ccxt/index.ts
@@ -24,7 +24,12 @@ export const CcxtExchangeService = async ({
 
   const client: ccxt.Exchange = new ccxt[exchangeId](config)
 
-  await client.loadMarkets()
+  try {
+    await client.loadMarkets()
+  } catch (error) {
+    baseLogger.error({ error }, "Ccxt unknown error")
+    return new UnknownExchangeServiceError(error.message || error)
+  }
 
   const fetchTicker = async (): Promise<Ticker | ServiceError> => {
     try {
@@ -32,7 +37,7 @@ export const CcxtExchangeService = async ({
       return tickerFromRaw(ticker)
     } catch (error) {
       baseLogger.error({ error }, "Ccxt unknown error")
-      return new UnknownExchangeServiceError(error)
+      return new UnknownExchangeServiceError(error.message || error)
     }
   }
 


### PR DESCRIPTION
Fix an exception when exchange is down 

```
ExchangeNotAvailable: bitfinex2 {"code":503,"error":"temporarily_unavailable","error_description":"Sorry, the service is temporarily unavailable. See https://www.bitfinex.com/ for more info."}
at bitfinex2.throwExactlyMatchedException (/app/node_modules/ccxt/js/base/Exchange.js:632:19)
at bitfinex2.handleErrors (/app/node_modules/ccxt/js/bitfinex2.js:1762:22)
at /app/node_modules/ccxt/js/base/Exchange.js:709:51
at processTicksAndRejections (node:internal/process/task_queues:96:5)
at async timeout (/app/node_modules/ccxt/js/base/functions/time.js:203:20)
at async bitfinex2.fetchCurrencies (/app/node_modules/ccxt/js/bitfinex2.js:469:26)
at async bitfinex2.loadMarketsHelper (/app/node_modules/ccxt/js/base/Exchange.js:780:26)
at async CcxtExchangeService (/app/services/exchanges/ccxt/index.js:17:5)
at async Object.create (/app/services/exchanges/index.js:17:27)
at async refreshRealtimeData (/app/app/realtime/refresh-realtime-data.js:12:29) {
constructor: [class ExchangeNotAvailable extends NetworkError]
}
```