### PR TITLE
chore: update okcoin frequency

### DIFF
--- a/realtime/default.yaml
+++ b/realtime/default.yaml
@@ -19,7 +19,7 @@ exchanges:
     base: "BTC"
     quote: "USD"
     provider: "ccxt"
-    cron: "*/5 * * * * *"
+    cron: "*/10 * * * * *"
   - name: "binance"
     enabled: true
     quoteAlias: "USD"


### PR DESCRIPTION
Okcoin ticker endpoint is returning errors.. increasing fetch frequency to try to avoid limiter