### PR TITLE
fix: update binance to use binance us

### DIFF
--- a/realtime/default.yaml
+++ b/realtime/default.yaml
@@ -20,11 +20,11 @@ exchanges:
     quote: "USD"
     provider: "ccxt"
     cron: "*/10 * * * * *"
-  - name: "binance"
+  - name: "binanceus"
     enabled: true
     quoteAlias: "USD"
     base: "BTC"
-    quote: "USDT"
+    quote: "USD"
     provider: "ccxt"
     cron: "*/5 * * * * *"
   - name: "exchangeratesapi"


### PR DESCRIPTION
Binance API was blocked to use from US IPs so the setting was updated to use binance us