### PR TITLE
feat: add currency beacon realtime provider

### DIFF
--- a/realtime/default.yaml
+++ b/realtime/default.yaml
@@ -26,6 +26,17 @@ exchanges:
     quote: "USD"
     provider: "ccxt"
     cron: "*/5 * * * * *"
+  - name: "currencybeacon"
+    enabled: false
+    quoteAlias: "*"
+    base: "USD"
+    quote: "*"
+    provider: "currencybeacon"
+    cron: "*/5 * * * * *"
+    config:
+      baseUrl: "https://api.currencybeacon.com/v1"
+      apiKey: "<your api key>"
+      cacheSeconds: 900
   - name: "exchangeratesapi"
     enabled: false
     quoteAlias: "CRC"

--- a/realtime/src/config/schema.ts
+++ b/realtime/src/config/schema.ts
@@ -31,7 +31,10 @@ export const configSchema = {
           quoteAlias: { type: "string", default: "USD" },
           base: { type: "string", default: "BTC" },
           quote: { type: "string", default: "USD" },
-          provider: { type: "string", enum: ["ccxt", "exchangeratesapi"] },
+          provider: {
+            type: "string",
+            enum: ["ccxt", "currencybeacon", "exchangeratesapi"],
+          },
           cron: { type: "string" },
           config: { type: "object" },
         },

--- a/realtime/src/services/exchanges/currencybeacon/index.ts
+++ b/realtime/src/services/exchanges/currencybeacon/index.ts
@@ -25,9 +25,9 @@ export const CurrencyBeaconExchangeService = async ({
   const url = baseUrl || "https://api.currencybeacon.com/v1"
   const cacheKey = `${CacheKeys.CurrentTicker}:currencybeacon:${base}:*`
 
-  const getCachedRates = async (): Promise<CurrencyBeaconRates | null> => {
+  const getCachedRates = async (): Promise<CurrencyBeaconRates | undefined> => {
     const cachedTickers = await LocalCacheService().get<CurrencyBeaconRates>(cacheKey)
-    if (cachedTickers instanceof Error) return null
+    if (cachedTickers instanceof Error) return undefined
     return cachedTickers
   }
 

--- a/realtime/src/services/exchanges/currencybeacon/index.ts
+++ b/realtime/src/services/exchanges/currencybeacon/index.ts
@@ -1,0 +1,95 @@
+import axios from "axios"
+
+import {
+  InvalidTickerError,
+  ExchangeServiceError,
+  UnknownExchangeServiceError,
+  InvalidExchangeConfigError,
+} from "@domain/exchanges"
+import { toPrice, toSeconds, toTimestamp } from "@domain/primitives"
+import { LocalCacheService } from "@services/cache"
+import { CacheKeys } from "@domain/cache"
+import { baseLogger } from "@services/logger"
+
+export const CurrencyBeaconExchangeService = async ({
+  base,
+  quote,
+  config,
+}: CurrencyBeaconExchangeServiceArgs): Promise<
+  IExchangeService | ExchangeServiceError
+> => {
+  if (!config || !config.apiKey) return new InvalidExchangeConfigError()
+
+  const { baseUrl, apiKey, timeout, cacheSeconds, ...params } = config
+
+  const url = baseUrl || "https://api.currencybeacon.com/v1"
+  const cacheKey = `${CacheKeys.CurrentTicker}:currencybeacon:${base}:*`
+
+  const getCachedRates = async (): Promise<CurrencyBeaconRates | null> => {
+    const cachedTickers = await LocalCacheService().get<CurrencyBeaconRates>(cacheKey)
+    if (cachedTickers instanceof Error) return null
+    return cachedTickers
+  }
+
+  const fetchTicker = async (): Promise<Ticker | ServiceError> => {
+    // We cant use response.data.response.date because
+    // CurrencyBeacon does not behave like a bitcoin exchange
+    const timestamp = new Date().getTime()
+
+    try {
+      const cachedRates = await getCachedRates()
+      if (cachedRates) return tickerFromRaw({ rate: cachedRates[quote], timestamp })
+
+      const response = await axios.get(`${url}/latest`, {
+        timeout: Number(timeout || 5000),
+        params: {
+          api_key: apiKey,
+          base,
+          ...params,
+        },
+      })
+      if (
+        response.status > 400 ||
+        !response.data.response ||
+        !response.data.response.rates ||
+        !Object.keys(response.data.response.rates).length
+      )
+        return new UnknownExchangeServiceError(
+          `Invalid response. Error ${response.status}`,
+        )
+
+      const rates = response.data.response.rates
+
+      await LocalCacheService().set<CurrencyBeaconRates>({
+        key: cacheKey,
+        value: rates,
+        ttlSecs: toSeconds(cacheSeconds > 0 ? Number(cacheSeconds) : 300),
+      })
+
+      return tickerFromRaw({ rate: rates[quote], timestamp })
+    } catch (error) {
+      baseLogger.error({ error }, "CurrencyBeacon unknown error")
+      return new UnknownExchangeServiceError(error)
+    }
+  }
+
+  return { fetchTicker }
+}
+
+const tickerFromRaw = ({
+  rate,
+  timestamp,
+}: {
+  rate: number
+  timestamp: number
+}): Ticker | InvalidTickerError => {
+  if (rate > 0 && timestamp > 0) {
+    return {
+      bid: toPrice(rate),
+      ask: toPrice(rate),
+      timestamp: toTimestamp(timestamp),
+    }
+  }
+
+  return new InvalidTickerError()
+}

--- a/realtime/src/services/exchanges/currencybeacon/index.types.d.ts
+++ b/realtime/src/services/exchanges/currencybeacon/index.types.d.ts
@@ -1,6 +1,18 @@
 type CurrencyBeaconConfig = { [key: string]: string | number | boolean }
 type CurrencyBeaconRates = { [key: string]: number }
 
+type GetCurrencyBeaconRatesResponse = {
+  meta: {
+    code: number
+    disclaimer: string
+  }
+  response: {
+    date: string
+    base: string
+    rates: unknown
+  }
+}
+
 type CurrencyBeaconExchangeServiceArgs = {
   base: string
   quote: string

--- a/realtime/src/services/exchanges/currencybeacon/index.types.d.ts
+++ b/realtime/src/services/exchanges/currencybeacon/index.types.d.ts
@@ -1,0 +1,8 @@
+type CurrencyBeaconConfig = { [key: string]: string | number | boolean }
+type CurrencyBeaconRates = { [key: string]: number }
+
+type CurrencyBeaconExchangeServiceArgs = {
+  base: string
+  quote: string
+  config?: CurrencyBeaconConfig
+}

--- a/realtime/src/services/exchanges/index.ts
+++ b/realtime/src/services/exchanges/index.ts
@@ -1,6 +1,7 @@
 import { InvalidExchangeProviderError } from "@domain/exchanges"
 
 import { CcxtExchangeService } from "./ccxt"
+import { CurrencyBeaconExchangeService } from "./currencybeacon"
 import { ExchangeRatesAPIExchangeService } from "./exchange-rates-api"
 
 const exchanges: { [key: string]: IExchangeService } = {}
@@ -20,6 +21,9 @@ export const ExchangeFactory = (): ExchangeFactory => {
       case "ccxt":
         service = await createCcxt(config)
         break
+      case "currencybeacon":
+        service = await createCurrencyBeacon(config)
+        break
       case "exchangeratesapi":
         service = await createExchangeRatesAPI(config)
         break
@@ -38,6 +42,16 @@ const createCcxt = async (config: ExchangeConfig) => {
   const defaultConfig = { enableRateLimit: true, rateLimit: 2000, timeout: 8000 }
   return CcxtExchangeService({
     exchangeId: name,
+    base: base,
+    quote: quote,
+    config: { ...defaultConfig, ...config.config },
+  })
+}
+
+const createCurrencyBeacon = async (config: ExchangeConfig) => {
+  const { base, quote } = config
+  const defaultConfig = { timeout: 5000 }
+  return CurrencyBeaconExchangeService({
     base: base,
     quote: quote,
     config: { ...defaultConfig, ...config.config },


### PR DESCRIPTION
Add https://currencybeacon.com/ realtime provider in order to provide ~multiple~ display currencies. It provides 5,000 Requests/month in free plan

if we want to use wildcard config we need to merge https://github.com/GaloyMoney/price/pull/35 first