### PR TITLE
feat: add free currency rates realtime provider

### DIFF
--- a/realtime/default.yaml
+++ b/realtime/default.yaml
@@ -3,6 +3,7 @@ base: "BTC"
 # the default is the first currency
 quotes:
   - { code: "USD", symbol: "$", name: "US Dollar", flag: "🇺🇸" }
+  - { code: "EUR", symbol: "€", name: "Euro", flag: "🇪🇺" }
 
 exchanges:
   - name: "bitfinex2"
@@ -26,6 +27,17 @@ exchanges:
     quote: "USD"
     provider: "ccxt"
     cron: "*/5 * * * * *"
+  - name: "free-currency-rates-usd"
+    enabled: true
+    quoteAlias: "*"
+    base: "USD"
+    quote: "*"
+    provider: "free-currency-rates"
+    cron: "*/5 * * * * *"
+    config:
+      baseUrl: "https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/"
+      fallbackUrl: "https://raw.githubusercontent.com/fawazahmed0/currency-api/1/latest/currencies/"
+      cacheSeconds: 1800
   - name: "currencybeacon"
     enabled: false
     quoteAlias: "*"

--- a/realtime/src/config/schema.ts
+++ b/realtime/src/config/schema.ts
@@ -33,7 +33,7 @@ export const configSchema = {
           quote: { type: "string", default: "USD" },
           provider: {
             type: "string",
-            enum: ["ccxt", "currencybeacon", "exchangeratesapi"],
+            enum: ["ccxt", "free-currency-rates", "currencybeacon", "exchangeratesapi"],
           },
           cron: { type: "string" },
           config: { type: "object" },

--- a/realtime/src/services/exchanges/free-currency-rates/index.ts
+++ b/realtime/src/services/exchanges/free-currency-rates/index.ts
@@ -1,0 +1,118 @@
+import axios, { AxiosResponse } from "axios"
+
+import {
+  InvalidTickerError,
+  ExchangeServiceError,
+  UnknownExchangeServiceError,
+  InvalidExchangeConfigError,
+} from "@domain/exchanges"
+import { toPrice, toSeconds, toTimestamp } from "@domain/primitives"
+import { LocalCacheService } from "@services/cache"
+import { CacheKeys } from "@domain/cache"
+import { baseLogger } from "@services/logger"
+
+export const FreeCurrencyRatesExchangeService = async ({
+  base,
+  quote,
+  config,
+}: FreeCurrencyRatesExchangeServiceArgs): Promise<
+  IExchangeService | ExchangeServiceError
+> => {
+  if (!config) return new InvalidExchangeConfigError()
+
+  const { baseUrl, fallbackUrl, timeout, cacheSeconds } = config
+
+  const url =
+    baseUrl || "https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/"
+  const cacheKey = `${CacheKeys.CurrentTicker}:freecurrencyrates:${base}:*`
+
+  const getCachedRates = async (): Promise<FreeCurrencyRatesRates | null> => {
+    const cachedTickers = await LocalCacheService().get<FreeCurrencyRatesRates>(cacheKey)
+    if (cachedTickers instanceof Error) return null
+    return cachedTickers
+  }
+
+  const fetchTicker = async (): Promise<Ticker | ServiceError> => {
+    // We cant use response.data.date because
+    // FreeCurrencyRates does not behave like a bitcoin exchange
+    const timestamp = new Date().getTime()
+    const baseCurrency = base.toLowerCase()
+    const quoteCurrency = quote.toLowerCase()
+
+    try {
+      const cachedRates = await getCachedRates()
+      if (cachedRates)
+        return tickerFromRaw({ rate: cachedRates[quoteCurrency], timestamp })
+      const urls = [
+        `${url}/${baseCurrency}.min.json`,
+        `${url}/${baseCurrency}.json`,
+        `${fallbackUrl}/${baseCurrency}.min.json`,
+        `${fallbackUrl}/${baseCurrency}.json`,
+      ]
+      const params = {
+        timeout: Number(timeout || 5000),
+      }
+
+      const response = await getWithFallback({ urls, params })
+      if (response instanceof Error) return response
+
+      if (
+        !response ||
+        !response[baseCurrency] ||
+        !Object.keys(response[baseCurrency]).length
+      )
+        return new UnknownExchangeServiceError("Invalid response.")
+
+      const rates = response[baseCurrency]
+
+      await LocalCacheService().set<FreeCurrencyRatesRates>({
+        key: cacheKey,
+        value: rates,
+        ttlSecs: toSeconds(cacheSeconds > 0 ? Number(cacheSeconds) : 300),
+      })
+
+      return tickerFromRaw({ rate: rates[quoteCurrency], timestamp })
+    } catch (error) {
+      baseLogger.error({ error }, "FreeCurrencyRates unknown error")
+      return new UnknownExchangeServiceError(error)
+    }
+  }
+
+  return { fetchTicker }
+}
+
+const tickerFromRaw = ({
+  rate,
+  timestamp,
+}: {
+  rate: number
+  timestamp: number
+}): Ticker | InvalidTickerError => {
+  if (rate > 0 && timestamp > 0) {
+    return {
+      bid: toPrice(rate),
+      ask: toPrice(rate),
+      timestamp: toTimestamp(timestamp),
+    }
+  }
+
+  return new InvalidTickerError()
+}
+
+const getWithFallback = async ({
+  urls,
+  params,
+}: {
+  urls: string[]
+  params: { [key: string]: string | number | boolean }
+}) => {
+  let response: AxiosResponse | undefined
+  for (const url of urls) {
+    try {
+      response = await axios.get(url, params)
+      if (response && response.status === 200) return response.data
+    } catch {}
+  }
+
+  return new UnknownExchangeServiceError(`Invalid response. Error ${response?.status}`)
+}

--- a/realtime/src/services/exchanges/free-currency-rates/index.ts
+++ b/realtime/src/services/exchanges/free-currency-rates/index.ts
@@ -41,8 +41,10 @@ export const FreeCurrencyRatesExchangeService = async ({
 
     try {
       const cachedRates = await getCachedRates()
-      if (cachedRates)
+      if (cachedRates) {
         return tickerFromRaw({ rate: cachedRates[quoteCurrency], timestamp })
+      }
+
       const urls = [
         `${url}/${baseCurrency}.min.json`,
         `${url}/${baseCurrency}.json`,

--- a/realtime/src/services/exchanges/free-currency-rates/index.types.d.ts
+++ b/realtime/src/services/exchanges/free-currency-rates/index.types.d.ts
@@ -1,0 +1,8 @@
+type FreeCurrencyRatesConfig = { [key: string]: string | number | boolean }
+type FreeCurrencyRatesRates = { [key: string]: number }
+
+type FreeCurrencyRatesExchangeServiceArgs = {
+  base: string
+  quote: string
+  config?: FreeCurrencyRatesConfig
+}

--- a/realtime/src/services/exchanges/index.ts
+++ b/realtime/src/services/exchanges/index.ts
@@ -3,6 +3,7 @@ import { InvalidExchangeProviderError } from "@domain/exchanges"
 import { CcxtExchangeService } from "./ccxt"
 import { CurrencyBeaconExchangeService } from "./currencybeacon"
 import { ExchangeRatesAPIExchangeService } from "./exchange-rates-api"
+import { FreeCurrencyRatesExchangeService } from "./free-currency-rates"
 
 const exchanges: { [key: string]: IExchangeService } = {}
 
@@ -20,6 +21,9 @@ export const ExchangeFactory = (): ExchangeFactory => {
     switch (provider) {
       case "ccxt":
         service = await createCcxt(config)
+        break
+      case "free-currency-rates":
+        service = await createFreeCurrencyRates(config)
         break
       case "currencybeacon":
         service = await createCurrencyBeacon(config)
@@ -42,6 +46,16 @@ const createCcxt = async (config: ExchangeConfig) => {
   const defaultConfig = { enableRateLimit: true, rateLimit: 2000, timeout: 8000 }
   return CcxtExchangeService({
     exchangeId: name,
+    base: base,
+    quote: quote,
+    config: { ...defaultConfig, ...config.config },
+  })
+}
+
+const createFreeCurrencyRates = async (config: ExchangeConfig) => {
+  const { base, quote } = config
+  const defaultConfig = { timeout: 5000 }
+  return FreeCurrencyRatesExchangeService({
     base: base,
     quote: quote,
     config: { ...defaultConfig, ...config.config },

--- a/realtime/test/examples/client-test.ts
+++ b/realtime/test/examples/client-test.ts
@@ -20,7 +20,7 @@ const client2 = new protoDescriptorHealth.grpc.health.v1.Health(
 client.listCurrencies({}, callback)
 client.getPrice({}, callback)
 
-client.getPrice({ currency: "CRC" }, callback)
+client.getPrice({ currency: "EUR" }, callback)
 client.getPrice({ currency: "USD" }, callback)
 
 function callback(err, data) {


### PR DESCRIPTION
PR https://github.com/GaloyMoney/price/pull/36  should be merged first

Add `Free Currency Rates API` https://github.com/fawazahmed0/currency-api as realtime provider

How to test:

```
make realtime-start-server
# open http://localhost:9464/metrics
# on another console
cd realtime
yarn ts-node --files -r tsconfig-paths/register test/examples/client-test.ts
```

metrics endpoint should return something like 
```
# HELP USD_price USD prices
# TYPE USD_price gauge
USD_price{label="median"} 16627.17 1672363596632
USD_price{label="bitfinex2"} 16637.5 1672363596632
USD_price{label="okcoin"} Nan 1672363596632
USD_price{label="binanceus"} 16616.84 1672363596632
# HELP EUR_price EUR prices
# TYPE EUR_price gauge
EUR_price{label="median"} 15633.88 1672363596632
EUR_price{label="free-currency-rates-usd"} 15633.88 1672363596632
```