### PR TITLE
feat: add mocked provider

### DIFF
--- a/history/package.json
+++ b/history/package.json
@@ -44,7 +44,7 @@
     "grpc-health-check": "^2.0.0",
     "js-yaml": "^4.1.0",
     "knex": "^3.0.1",
-    "lodash.merge": "^4.6.2",
+    "lodash.mergewith": "^4.6.2",
     "node-cron": "^3.0.3",
     "pg": "^8.11.0",
     "pino": "^8.16.2"

--- a/history/prettier.config.js
+++ b/history/prettier.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  // Custom:
+  semi: false,
+  trailingComma: "all",
+  printWidth: 90,
+  quoteProps: "consistent",
+  // Defaults:
+  singleQuote: false,
+  tabWidth: 2,
+  useTabs: false,
+  bracketSpacing: true,
+  arrowParens: "always",
+  proseWrap: "preserve",
+  endOfLine: "lf",
+}

--- a/history/src/config/yaml.ts
+++ b/history/src/config/yaml.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 
 import yaml from "js-yaml"
-import merge from "lodash.merge"
+import mergeWith from "lodash.mergewith"
 import Ajv from "ajv"
 
 import { baseLogger } from "@services/logger"
@@ -11,6 +11,9 @@ import { ConfigSchema, configSchema } from "./schema"
 
 const defaultContent = fs.readFileSync("./default.yaml", "utf8")
 export const defaultConfig = yaml.load(defaultContent)
+
+const merge = (defaultConfig: unknown, customConfig: unknown) =>
+  mergeWith(defaultConfig, customConfig, (a, b) => (Array.isArray(b) ? b : undefined))
 
 let customConfig
 

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -38,7 +38,7 @@
     "dotenv": "^16.0.3",
     "grpc-health-check": "^2.0.0",
     "js-yaml": "^4.1.0",
-    "lodash.merge": "^4.6.2",
+    "lodash.mergewith": "^4.6.2",
     "node-cache": "^5.1.2",
     "node-cron": "^3.0.3",
     "pino": "^8.16.2"

--- a/realtime/package.json
+++ b/realtime/package.json
@@ -12,6 +12,7 @@
     "monitoring": "ts-node --files -r tsconfig-paths/register src/servers/realtime/run-monitoring.ts",
     "start": "ts-node --files -r tsconfig-paths/register src/servers/realtime/run.ts",
     "test:unit": "jest --config ./test/jest-unit.config.js --bail --verbose $TEST | yarn pino-pretty -c -l",
+    "test:watch-unit": "LOGLEVEL=warn jest --config ./test/jest-unit.config.js --bail --verbose --watch $TEST",
     "tsc-check": "tsc --noEmit -p tsconfig.d.json && tsc --noEmit --skipLibCheck",
     "watch-compile": "tsc --watch  --noEmit --skipLibCheck"
   },

--- a/realtime/prettier.config.js
+++ b/realtime/prettier.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  // Custom:
+  semi: false,
+  trailingComma: "all",
+  printWidth: 90,
+  quoteProps: "consistent",
+  // Defaults:
+  singleQuote: false,
+  tabWidth: 2,
+  useTabs: false,
+  bracketSpacing: true,
+  arrowParens: "always",
+  proseWrap: "preserve",
+  endOfLine: "lf",
+}

--- a/realtime/sample-dev-custom.yaml
+++ b/realtime/sample-dev-custom.yaml
@@ -1,0 +1,13 @@
+exchanges:
+  - provider: "dev-mock"
+    base: "BTC"
+    quote: "*"
+    enabled: true
+    config:
+      devMockPrice:
+        BTC:
+          EUR: 25910
+          USD: 28275.07
+    # Following require dummy values
+    name: ""
+    cron: "*/5 * * * * *"

--- a/realtime/src/app/realtime/index.types.d.ts
+++ b/realtime/src/app/realtime/index.types.d.ts
@@ -1,6 +1,6 @@
 type RefreshRealtimeDataArgs = {
   currency: CurrencyCode
-  exchange: ExchangeConfig
+  exchange: DevExchangeConfig | ExchangeConfig
 }
 
 type RefreshDataCallbackArgs = {

--- a/realtime/src/app/realtime/start-watchers.ts
+++ b/realtime/src/app/realtime/start-watchers.ts
@@ -25,7 +25,7 @@ const startWatcher = async ({
   callback,
 }: {
   currency: CurrencyCode
-  exchange: ExchangeConfig
+  exchange: DevExchangeConfig | ExchangeConfig
   callback?: RefreshDataCallback
 }): Promise<ScheduledTask> => {
   const task = async () => {

--- a/realtime/src/config/index.types.d.ts
+++ b/realtime/src/config/index.types.d.ts
@@ -9,7 +9,7 @@ type RawExchangeConfig = {
   config: { [key: string]: string | number | boolean }
 }
 
-type ExchangeConfig = {
+type PartialExchangeConfig = {
   name: string
   base: string
   quote: string
@@ -17,5 +17,12 @@ type ExchangeConfig = {
   excludedQuotes: string[]
   provider: string
   cron: string
+}
+
+type ExchangeConfig = PartialExchangeConfig & {
   config: { [key: string]: string | number | boolean }
+}
+
+type DevExchangeConfig = PartialExchangeConfig & {
+  config: MockedConfig
 }

--- a/realtime/src/config/index.types.d.ts
+++ b/realtime/src/config/index.types.d.ts
@@ -6,7 +6,7 @@ type RawExchangeConfig = {
   quoteAlias: string[]
   provider: string
   cron: string
-  config: { [key: string]: string | number | boolean }
+  config: { [key: string]: string | number | boolean } | MockedConfig
 }
 
 type PartialExchangeConfig = {

--- a/realtime/src/config/schema.ts
+++ b/realtime/src/config/schema.ts
@@ -44,6 +44,7 @@ export const configSchema = {
           provider: {
             type: "string",
             enum: [
+              "dev-mock",
               "ccxt",
               "free-currency-rates",
               "currencybeacon",

--- a/realtime/src/config/yaml.ts
+++ b/realtime/src/config/yaml.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 
 import yaml from "js-yaml"
-import merge from "lodash.merge"
+import mergeWith from "lodash.mergewith"
 import * as cron from "node-cron"
 import Ajv from "ajv"
 
@@ -12,6 +12,9 @@ import { ConfigSchema, configSchema } from "./schema"
 
 const defaultContent = fs.readFileSync("./default.yaml", "utf8")
 export const defaultConfig = yaml.load(defaultContent)
+
+const merge = (defaultConfig: unknown, customConfig: unknown) =>
+  mergeWith(defaultConfig, customConfig, (a, b) => (Array.isArray(b) ? b : undefined))
 
 let customConfig
 

--- a/realtime/src/config/yaml.ts
+++ b/realtime/src/config/yaml.ts
@@ -67,6 +67,11 @@ export const defaultBaseCurrency: CurrencyCode = yamlConfig.base
 export const defaultQuoteCurrency: FiatCurrency = supportedCurrencies[0]
 
 export const getExchangesConfig = (): ExchangeConfig[] => {
+  // Set dev mode if dev config is present
+  if (yamlConfig.exchanges.find((e) => e.provider === "dev-mock")) {
+    yamlConfig.exchanges = yamlConfig.exchanges.filter((e) => e.provider === "dev-mock")
+  }
+
   const enabledRawExchangesConfig: RawExchangeConfig[] = yamlConfig.exchanges
     .filter((e) => !!e.enabled)
     .map((e) => {

--- a/realtime/src/domain/exchanges/index.types.d.ts
+++ b/realtime/src/domain/exchanges/index.types.d.ts
@@ -16,5 +16,7 @@ interface IExchangeService {
 }
 
 type ExchangeFactory = {
-  create(config: ExchangeConfig): Promise<IExchangeService | ExchangeServiceError>
+  create(
+    config: DevExchangeConfig | ExchangeConfig,
+  ): Promise<IExchangeService | ExchangeServiceError>
 }

--- a/realtime/src/services/exchanges/mocked/index.ts
+++ b/realtime/src/services/exchanges/mocked/index.ts
@@ -1,0 +1,48 @@
+import {
+  InvalidTickerError,
+  ExchangeServiceError,
+  InvalidExchangeConfigError,
+} from "@domain/exchanges"
+import { toPrice, toTimestamp } from "@domain/primitives"
+
+export const MockedExchangeService = async ({
+  base,
+  quote,
+  config,
+}: MockedExchangeServiceArgs): Promise<IExchangeService | ExchangeServiceError> => {
+  const devMockPrice = config?.devMockPrice
+  if (!(devMockPrice && Object.keys(devMockPrice).includes(base))) {
+    return new InvalidExchangeConfigError(`Config missing base '${base}'`)
+  }
+  if (!Object.keys(devMockPrice[base]).includes(quote)) {
+    return new InvalidExchangeConfigError(
+      `Config base missing quote '${quote}' for base '${base}'`,
+    )
+  }
+
+  const fetchTicker = async (): Promise<Ticker | ServiceError> =>
+    tickerFromRaw({
+      rate: devMockPrice[base][quote],
+      timestamp: new Date().getTime(),
+    })
+
+  return { fetchTicker }
+}
+
+const tickerFromRaw = ({
+  rate,
+  timestamp,
+}: {
+  rate: number
+  timestamp: number
+}): Ticker | InvalidTickerError => {
+  if (rate > 0 && timestamp > 0) {
+    return {
+      bid: toPrice(rate),
+      ask: toPrice(rate),
+      timestamp: toTimestamp(timestamp),
+    }
+  }
+
+  return new InvalidTickerError()
+}

--- a/realtime/src/services/exchanges/mocked/index.ts
+++ b/realtime/src/services/exchanges/mocked/index.ts
@@ -11,9 +11,14 @@ export const MockedExchangeService = async ({
   config,
 }: MockedExchangeServiceArgs): Promise<IExchangeService | ExchangeServiceError> => {
   const devMockPrice = config?.devMockPrice
-  if (!(devMockPrice && Object.keys(devMockPrice).includes(base))) {
+  if (!(devMockPrice && typeof devMockPrice === "object")) {
+    return new InvalidExchangeConfigError(`Bad dev config passed`)
+  }
+
+  if (!Object.keys(devMockPrice).includes(base)) {
     return new InvalidExchangeConfigError(`Config missing base '${base}'`)
   }
+
   if (!Object.keys(devMockPrice[base]).includes(quote)) {
     return new InvalidExchangeConfigError(
       `Config base missing quote '${quote}' for base '${base}'`,

--- a/realtime/src/services/exchanges/mocked/index.types.d.ts
+++ b/realtime/src/services/exchanges/mocked/index.types.d.ts
@@ -9,5 +9,5 @@ type MockedConfig = {
 type MockedExchangeServiceArgs = {
   base: string
   quote: string
-  config?: ExchangeConfig["config"] | MockedConfig
+  config?: DevExchangeConfig["config"]
 }

--- a/realtime/src/services/exchanges/mocked/index.types.d.ts
+++ b/realtime/src/services/exchanges/mocked/index.types.d.ts
@@ -1,0 +1,13 @@
+type MockedConfig = {
+  devMockPrice: {
+    [key: string]: {
+      [key: string]: number
+    }
+  }
+}
+
+type MockedExchangeServiceArgs = {
+  base: string
+  quote: string
+  config?: MockedConfig
+}

--- a/realtime/src/services/exchanges/mocked/index.types.d.ts
+++ b/realtime/src/services/exchanges/mocked/index.types.d.ts
@@ -9,5 +9,5 @@ type MockedConfig = {
 type MockedExchangeServiceArgs = {
   base: string
   quote: string
-  config?: MockedConfig
+  config?: ExchangeConfig["config"] | MockedConfig
 }

--- a/realtime/test/unit/services/exchanges/mocked.spec.ts
+++ b/realtime/test/unit/services/exchanges/mocked.spec.ts
@@ -1,0 +1,53 @@
+import { toPrice, toTimestamp } from "@domain/primitives"
+import { InvalidExchangeConfigError } from "@domain/exchanges"
+
+import { MockedExchangeService } from "@services/exchanges/mocked"
+
+describe("MockedExchangeService", () => {
+  it("should return InvalidExchangeConfigError if config is not provided", async () => {
+    const service = await MockedExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: undefined,
+    })
+    expect(service).toBeInstanceOf(InvalidExchangeConfigError)
+  })
+
+  it("should return expected tickers from config", async () => {
+    const usdService = await MockedExchangeService({
+      base: "BTC",
+      quote: "USD",
+      config: {
+        devMockPrice: {
+          BTC: { EUR: 25910, USD: 28275.07 },
+        },
+      },
+    })
+    if (usdService instanceof Error) throw usdService
+
+    const usdResult = await usdService.fetchTicker()
+    expect(usdResult).toEqual({
+      bid: toPrice(28275.07),
+      ask: toPrice(28275.07),
+      timestamp: toTimestamp(expect.any(Number)),
+    })
+
+    const eurService = await MockedExchangeService({
+      base: "BTC",
+      quote: "EUR",
+      config: {
+        devMockPrice: {
+          BTC: { EUR: 25910, USD: 28275.07 },
+        },
+      },
+    })
+    if (eurService instanceof Error) throw eurService
+
+    const eurResult = await eurService.fetchTicker()
+    expect(eurResult).toEqual({
+      bid: toPrice(25910),
+      ask: toPrice(25910),
+      timestamp: toTimestamp(expect.any(Number)),
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4305,6 +4305,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
 lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"


### PR DESCRIPTION
## Description

This is to allow the configuration of mock values for realtime price for cases like testing purposes, similar to how this was introduced in `stablesats` [here](https://github.com/GaloyMoney/stablesats-rs/commit/8299210f97b9084dd0570502e5fdb11dcf4888f5)