### PR TITLE
feat(realtime): add tracing filter

### DIFF
--- a/realtime/src/app/index.ts
+++ b/realtime/src/app/index.ts
@@ -11,6 +11,7 @@ for (const subModule in allFunctions) {
     allFunctions[subModule][fn] = wrapAsyncToRunInSpan({
       namespace: `app.${subModule.toLowerCase()}`,
       fn: allFunctions[subModule][fn],
+      root: true,
     })
   }
 }

--- a/realtime/src/config/process.ts
+++ b/realtime/src/config/process.ts
@@ -1,3 +1,4 @@
 export const tracingConfig = {
   otelServiceName: process.env.OTEL_SERVICE_NAME || "galoy-price-dev",
+  enableFilter: process.env.TRACING_ENABLE_FILTER === "true",
 }

--- a/realtime/src/domain/primitives/errors.ts
+++ b/realtime/src/domain/primitives/errors.ts
@@ -1,5 +1,7 @@
-import { DomainError } from "@domain/errors"
+import { DomainError, ErrorLevel } from "@domain/errors"
 
 class PrimitivesError extends DomainError {}
 
-export class InvalidCurrencyError extends PrimitivesError {}
+export class InvalidCurrencyError extends PrimitivesError {
+  level = ErrorLevel.Warn
+}

--- a/realtime/src/services/tracing.ts
+++ b/realtime/src/services/tracing.ts
@@ -64,6 +64,17 @@ class SpanProcessorWrapper extends SimpleSpanProcessor {
     }
     super.onStart(span, parentContext)
   }
+
+  onEnd(span: SdkSpan) {
+    if (tracingConfig.enableFilter) {
+      const errorLevel = span.attributes["error.level"]
+      if (!errorLevel || errorLevel === ErrorLevel.Info) {
+        return // Ignore the span if it has no error or if error is info level
+      }
+    }
+
+    super.onEnd(span)
+  }
 }
 
 provider.addSpanProcessor(new SpanProcessorWrapper(new OTLPTraceExporter()))


### PR DESCRIPTION
Add the option to set `TRACING_ENABLE_FILTER` env variable to filter and send only spans with warn or critical errors