### PR TITLE
fix: update node to 20.20.0-alpine

### DIFF
--- a/history/Dockerfile
+++ b/history/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS BUILD_IMAGE
+FROM node:20.20.0-alpine AS BUILD_IMAGE
 
 RUN apk update && apk add python3 make g++
 
@@ -13,7 +13,7 @@ RUN rm -rf /app/node_modules
 RUN rm -rf /app/history/node_modules
 RUN yarn install --frozen-lockfile --production
 
-FROM node:20-alpine
+FROM node:20.20.0-alpine
 COPY --from=BUILD_IMAGE /app/history/dist /app
 COPY --from=BUILD_IMAGE /app/history/scripts /app/scripts
 COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules

--- a/history/Dockerfile-migrate
+++ b/history/Dockerfile-migrate
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20.20.0-alpine
 
 WORKDIR /app
 COPY ./history/src/config/process.ts ./history/src/config/database.ts ./

--- a/realtime/Dockerfile
+++ b/realtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS BUILD_IMAGE
+FROM node:20.20.0-alpine AS BUILD_IMAGE
 
 RUN apk update && apk add python3 make g++
 
@@ -13,7 +13,7 @@ RUN rm -rf /app/node_modules
 RUN rm -rf /app/realtime/node_modules
 RUN yarn install --frozen-lockfile --production
 
-FROM node:20-alpine
+FROM node:20.20.0-alpine
 COPY --from=BUILD_IMAGE /app/realtime/dist /app
 COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules
 COPY --from=BUILD_IMAGE /app/realtime/node_modules /app/node_modules


### PR DESCRIPTION
## Summary
- Update all Dockerfiles (`realtime/Dockerfile`, `history/Dockerfile`, `history/Dockerfile-migrate`) from `node:20-alpine` to `node:20.20.0-alpine`
- CVE mitigation: https://nodejs.org/en/blog/vulnerability/january-2026-dos-mitigation-async-hooks

Resolves blinkbitcoin/blink-wip#395

## Test plan
- [x] Build realtime image locally
- [x] CI passes
- [ ] Deploy staging + verify `node --version` = 20.20.0
- [ ] Deploy prod + verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)