### PR TITLE
fix(history): handle loadMarkets failure gracefully

### DIFF
--- a/history/src/app/history/update-price-history.ts
+++ b/history/src/app/history/update-price-history.ts
@@ -14,6 +14,7 @@ const exchangeFactory = ExchangeFactory()
 
 export const updatePriceHistory = async (): Promise<boolean | ApplicationError> => {
   const exchanges = getExchangesConfig()
+  let anyExchangeSucceeded = false
 
   for (const exchange of exchanges) {
     const prices: Tick[] = []
@@ -58,9 +59,10 @@ export const updatePriceHistory = async (): Promise<boolean | ApplicationError> 
       continue
     }
     baseLogger.info({ recordsUpdated: result, exchange: name }, "Price history updated")
+    anyExchangeSucceeded = true
   }
 
-  return true
+  return anyExchangeSucceeded
 }
 
 const queryByRange = async ({

--- a/history/src/app/history/update-price-history.ts
+++ b/history/src/app/history/update-price-history.ts
@@ -19,6 +19,7 @@ export const updatePriceHistory = async (): Promise<boolean | ApplicationError> 
     const prices: Tick[] = []
     const { name, base, quote } = exchange
 
+    let exchangeFailed = false
     for (const range in PriceRange) {
       const result = await queryByRange({ range: PriceRange[range], exchange })
       if (result instanceof Error) {
@@ -31,7 +32,8 @@ export const updatePriceHistory = async (): Promise<boolean | ApplicationError> 
           },
           "Could not query price history",
         )
-        return result
+        exchangeFailed = true
+        break
       }
       baseLogger.info(
         { records: result.length, range: PriceRange[range], exchange: name },
@@ -39,6 +41,8 @@ export const updatePriceHistory = async (): Promise<boolean | ApplicationError> 
       )
       prices.push(...result)
     }
+
+    if (exchangeFailed) continue
 
     const result = await PriceRepository().updatePrices({
       exchange: name,
@@ -51,7 +55,7 @@ export const updatePriceHistory = async (): Promise<boolean | ApplicationError> 
         { error: result, message: result.message, exchange: name },
         "Could not update price history",
       )
-      return result
+      continue
     }
     baseLogger.info({ recordsUpdated: result, exchange: name }, "Price history updated")
   }

--- a/history/src/services/exchanges/ccxt/index.ts
+++ b/history/src/services/exchanges/ccxt/index.ts
@@ -24,7 +24,12 @@ export const CcxtExchangeService = async ({
 
   const client: Exchange = new ccxt[exchangeId](config)
 
-  await client.loadMarkets()
+  try {
+    await client.loadMarkets()
+  } catch (error) {
+    baseLogger.error({ error, exchangeId }, "Failed to load markets")
+    return new UnknownExchangeServiceError(error)
+  }
 
   const listPrices = async ({
     timeframe,

--- a/history/src/services/exchanges/ccxt/index.ts
+++ b/history/src/services/exchanges/ccxt/index.ts
@@ -28,7 +28,8 @@ export const CcxtExchangeService = async ({
     await client.loadMarkets()
   } catch (error) {
     baseLogger.error({ error, exchangeId }, "Failed to load markets")
-    return new UnknownExchangeServiceError(error)
+    const message = error instanceof Error ? error.message : String(error)
+    return new UnknownExchangeServiceError(message)
   }
 
   const listPrices = async ({

--- a/history/src/services/exchanges/ccxt/index.ts
+++ b/history/src/services/exchanges/ccxt/index.ts
@@ -40,13 +40,22 @@ export const CcxtExchangeService = async ({
     try {
       if (!client.has.fetchOHLCV) return new OHLCVNotSupportedExchangeServiceError()
 
+      if (client.timeframes && !(timeframe in client.timeframes)) {
+        baseLogger.warn(
+          { exchangeId, timeframe },
+          "Timeframe not supported by exchange, skipping",
+        )
+        return []
+      }
+
       const ohlc = await client.fetchOHLCV(symbol, timeframe, since, limit)
       if (!ohlc || !ohlc.length) return []
 
       return ohlc.map(exchangePriceFromRaw).filter(isExchangePrice)
     } catch (error) {
-      baseLogger.error({ error }, "Ccxt unknown error")
-      return new UnknownExchangeServiceError(error)
+      baseLogger.error({ error, exchangeId }, "Ccxt unknown error")
+      const message = error instanceof Error ? error.message : String(error)
+      return new UnknownExchangeServiceError(message)
     }
   }
 


### PR DESCRIPTION
Wrap ccxt loadMarkets() call in try/catch so that a single exchange
being unavailable (e.g. Bitfinex 503 maintenance) returns an error
instead of crashing the entire cron process.

Convert caught error to a string message for UnknownExchangeServiceError
since DomainError constructor expects a string, not an Error object.

Change updatePriceHistory() to continue to the next exchange on failure
instead of short-circuiting the entire cron run. This ensures other
enabled exchanges still update price history normally when one is down.